### PR TITLE
Add EFCore.TimeTraveler to the list of EF Core Extensions

### DIFF
--- a/entity-framework/core/extensions/index.md
+++ b/entity-framework/core/extensions/index.md
@@ -122,9 +122,16 @@ An implementation of temporal support. For EF Core: 2.
 
 ### EfCoreTemporalTable
 
-Easily perform temporal queries on your favourite database. For EF Core: 3.
+Easily perform temporal queries on your favourite database using introduced extension methods: `AsTemporalAll()`, `AsTemporalAsOf(date)`, `AsTemporalFrom(startDate, endDate)`, `AsTemporalBetween(startDate, endDate)`, `AsTemporalContained(startDate, endDate)`. For EF Core: 3.
 
 [GitHub repository](https://github.com/glautrou/EfCoreTemporalTable)
+
+### EFCore.TimeTraveler
+
+Allow full-featured Entity Framework Core queries against SQL Server Temporal History Tables using the EF Core code, entities, and mappings you already have defined.  Travel through time by wrapping your code in `using (TemporalQuery.AsOf(targetDateTime)) {...}`. For EF Core: 3.
+
+[GitHub repository](https://github.com/VantageSoftware/EFCore.TimeTraveler)
+
 
 ### EntityFrameworkCore.TemporalTables
 


### PR DESCRIPTION
Expand on differences between EFCore.TimeTraveler and EfCoreTemporalTable.

I didn't want to be too verbose here, so I left these details out:
* `EfCoreTemporalTable` exposes the full power of SQL Server Temporal Table history by supporting all available types of temporal queries.  
* `EFCore.TimeTraveler` focuses only on querying for a point in time with `FOR SYSTEM_TIME AS OF`
* With `EfCoreTemporalTable` you query multiple entities from history using JOIN syntax.
* With `EFCore.TimeTraveler` you may use `.Include()`, '.ThenInclude()', and navigation properties to access an entire object graph persisted from the temporal history of multiple tables.
